### PR TITLE
[feat] process csv and send output

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
         id="csvFile"
         type="file"
         placeholder="Upload csv"
+        accept=".csv"
       />
       <button id="detectButton">Detect Provider</button>
       <h1 id="result"></h1>
@@ -37,5 +38,6 @@
     </footer>
     <!--links to javascript tags-->
     <script src="./src/index.js" type="module"></script>
+    <script src="https://cdn.jsdelivr.net/npm/d3@7"></script>
   </body>
 </html>

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,5 @@
 import { predictDigit } from './predict-digit.js';
 
-function resetInput(field) {
-  if (field.value !== '') {
-    field.value = '';
-  }
-}
-
 // check if DOM is loaded first
 document?.addEventListener('DOMContentLoaded', () => {
   // get all inputs by ID
@@ -18,8 +12,6 @@ document?.addEventListener('DOMContentLoaded', () => {
   detectButton?.addEventListener('click', () => {
     const number = numberInput.value; // get the value of input
 
-    const csvFile = csv.value
-
     if (number) {
       const provider = predictDigit(number); // send to algorithm
 
@@ -28,8 +20,14 @@ document?.addEventListener('DOMContentLoaded', () => {
       resetInput(numberInput) // reset input
     }
     
-    else if (csvFile) {
-      console.log('File!')
+    else if (csv.value) {
+      const reader = new FileReader()
+      reader.onload = () => {
+        const numbers = d3.csvParse(reader.result)
+        console.log(detectIsp(numbers))
+        // document.getElementById('result').innerHTML = detectIsp(numbers)
+      }
+      if(csvFile.files[0]) reader.readAsText(csvFile.files[0])
       resetInput(csv)
     }
 
@@ -37,7 +35,17 @@ document?.addEventListener('DOMContentLoaded', () => {
       resultElement.textContent = 'Please provide a value to detect';
     }
 
-
-    
   });
 });
+
+function resetInput(field) {
+  if (field.value !== '') {
+    field.value = '';
+  }
+}
+
+function detectIsp(obj) {
+  for (let i = 0; i < obj.length; i++)
+    obj[i]['isp'] = predictDigit(`0${obj[i].Number}`)
+  return obj
+}


### PR DESCRIPTION
I have been able to process the csv file and detect the ISP from each number. This PR fixes #56 
> The received input

![Screenshot from 2023-06-24 18-39-58](https://github.com/sailscasts/mobile-number-issuer-detector/assets/57006897/5c4b35bf-7b8d-45d1-b92a-8ac4280b0aff)

> After processing and detecting the ISP

![Screenshot from 2023-06-24 18-44-06](https://github.com/sailscasts/mobile-number-issuer-detector/assets/57006897/d9c9d731-52ad-4428-8440-8465ba7ee23b)

This proves that we can now detect numbers from CSV files in that format